### PR TITLE
Added steps for VPC to VPC Communication using TGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Once TGW is created and configured . Based on (`cidr_tgw`) , new routes will be 
 
 You can also attach an already created TGW, based on the (`tgw_id`). Also use resource sharing you can share the TGW across Organization / OU or Account.
 
+We want to have route traffic to existing VPCs from the newly created VPC using TGW . Conditions for attaching existing TGW works here too and in addition to it set (`attach_tgw_route_vpc`) to true and provide the existing TGW Route table id (`tgw_rt_id`) . Now the newly created VPCs TGW attachment will be added in propagation and association in the existing TGW Route table . Please provide the VPC CIDR in `cidr_tgw` to which the newly created VPC has to communicate .
+
 ## Terraform version
 
 Terraform version 0.10.3 or newer is required for this module to work.
@@ -200,6 +202,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 
 * [Simple VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc)
 * [Simple VPC with TGW](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc-tgw)
+* [Simple VPC to VPC using TGW](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc-to-vpc)
 * [Simple VPC Hub and spoke using TGW](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc-hub-and-spoke)
 * [Cross Account VPC Hub & Spoke using TGW](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/cross-account-vpc-hub-and-spoke)
 * [Complete VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/complete-vpc)
@@ -219,6 +222,8 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `"false"` | no |
 | attach\_tgw| Attaches an existing TGW to this VPC| string | `"false"` | no |
 | attach\_tgw\_id | TGW ID to attach to the VPC this variable works in conjunction with attach_tgw | string | `""` | no |
+| attach\_tgw\_route\_vpc| Attaches an existing TGW to this VPC using existing TGW Route table| string | `"false"` | no |
+| tgw\_rt\_id | TGW Route table ID to attach to this VPC Attachment, this variable works in conjunction with attach_tgw_route_vpc | string | `""` | no |
 | azs | A list of availability zones in the region | list | `[]` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `"0.0.0.0/0"` | no |
 | create\_database\_internet\_gateway\_route | Controls if an internet gateway route for public database access should be created | string | `"false"` | no |
@@ -434,9 +439,10 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | vpc\_instance\_tenancy | Tenancy of instances spin up within VPC |
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
 | vpc\_secondary\_cidr\_blocks | List of secondary CIDR blocks of the VPC |
-| create\_tgw | Contros if Transit Gateway should be create | string | `"false"` | no |
-| subnet\_type\_tgw\_attachment | Controls the subnet type which will added in TGW Attachment | `"private"` | no |
-| cidr\_tgw | The route which will be added to subnets . The Destination cidr will be cidr_tgw and Target will be TGW id | `"private"` | no |
+`"private"` | no |
+| tgw\_id | The ID of the TGW |
+| tgw\_rt\_id | The ID of the TGW Route table |
+
 
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc-to-vpc/README.md
+++ b/examples/simple-vpc-to-vpc/README.md
@@ -1,0 +1,30 @@
+# Simple VPC to VPC routing
+
+Configuration in this directory creates a Two VPC which are attached to a TGW and they will will be able to route traffice between each other.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| azs | A list of availability zones spefified as argument to this module |
+| nat\_public\_ips | List of public Elastic IPs created for AWS NAT Gateway |
+| private\_subnets | List of IDs of private subnets |
+| public\_subnets | List of IDs of public subnets |
+| vpc\_cidr\_block | The CIDR block of the VPC |
+| vpc\_id | The ID of the VPC |
+| tgw\_id | The ID of the TGW |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc-to-vpc/main.tf
+++ b/examples/simple-vpc-to-vpc/main.tf
@@ -1,0 +1,91 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "vpc-1" {
+  source = "../../"
+
+  name = "VPC-1"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  assign_generated_ipv6_cidr_block = false
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  create_tgw                 = true
+  subnet_type_tgw_attachment = "public"
+  cidr_tgw                   = ["10.1.0.0/16"]
+
+  public_subnet_tags = {
+    Name = "public"
+  }
+
+  private_subnet_tags = {
+    Name = "private"
+  }
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev1"
+  }
+
+  vpc_tags = {
+    Name = "transit-tgw"
+  }
+
+  tgw_tags = {
+    Name = "tgw"
+  }
+}
+
+module "vpc-2" {
+  source = "../../"
+
+  name = "VPC-2"
+
+  cidr = "10.1.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.1.1.0/24", "10.1.2.0/24", "10.1.3.0/24"]
+  public_subnets  = ["10.1.101.0/24", "10.1.102.0/24", "10.1.103.0/24"]
+
+  assign_generated_ipv6_cidr_block = false
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  attach_tgw           = true
+  attach_tgw_id        = "${element(module.vpc-1.tgw_id, 0)}"
+  attach_tgw_route_vpc = true
+  tgw_rt_id            = "${element(module.vpc-1.tgw_rt_id, 0)}"
+
+  subnet_type_tgw_attachment = "public"
+  cidr_tgw                   = ["10.0.0.0/16"]
+
+  public_subnet_tags = {
+    Name = "public"
+  }
+
+  private_subnet_tags = {
+    Name = "private"
+  }
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev2"
+  }
+
+  vpc_tags = {
+    Name = "transit-tgw"
+  }
+
+  tgw_tags = {
+    Name = "tgw"
+  }
+}

--- a/examples/simple-vpc-to-vpc/outputs.tf
+++ b/examples/simple-vpc-to-vpc/outputs.tf
@@ -1,0 +1,76 @@
+# VPC-1
+output "vpc-1_vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc-1.vpc_id}"
+}
+
+# CIDR blocks
+output "vpc-1_vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = ["${module.vpc-1.vpc_cidr_block}"]
+}
+
+# Subnets
+output "vpc-1_private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${module.vpc-1.private_subnets}"]
+}
+
+output "vpc-1_public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${module.vpc-1.public_subnets}"]
+}
+
+# NAT gateways
+output "vpc-1_nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = ["${module.vpc-1.nat_public_ips}"]
+}
+
+# AZs
+output "vpc-1_azs" {
+  description = "A list of availability zones spefified as argument to this module"
+  value       = ["${module.vpc-1.azs}"]
+}
+
+output "vpc-1_tgw_id" {
+  description = "Transist Gateway ID"
+  value       = ["${module.vpc-1.tgw_id}"]
+}
+
+# VPC-2
+output "vpc-2_vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc-2.vpc_id}"
+}
+
+# CIDR blocks
+output "vpc-2_vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = ["${module.vpc-2.vpc_cidr_block}"]
+}
+
+# Subnets
+output "vpc-2_private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${module.vpc-2.private_subnets}"]
+}
+
+output "vpc-2_public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${module.vpc-2.public_subnets}"]
+}
+
+# NAT gateways
+output "vpc-2_nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = ["${module.vpc-2.nat_public_ips}"]
+}
+
+# AZs
+output "vpc-2_azs" {
+  description = "A list of availability zones spefified as argument to this module"
+  value       = ["${module.vpc-2.azs}"]
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -939,7 +939,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 }
 
 resource "aws_ec2_transit_gateway_route_table" "this" {
-  count = "${(var.create_tgw || var.attach_tgw) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public")? 1 : 0}"
+  count = "${(var.attach_tgw  && var.attach_tgw_route_vpc ? false:true) && (var.create_tgw || var.attach_tgw) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public")? 1 : 0}"
+  # count = "${false && (var.create_tgw || var.attach_tgw) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public")? 1 : 0}"
 
   transit_gateway_id = "${element(concat(aws_ec2_transit_gateway.this.*.id, list(var.attach_tgw_id)), 0)}"
 
@@ -950,17 +951,31 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
 # Transit Gateway Route table association and propagation for TGW Attachements
 #########
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
-  count = "${(var.create_tgw || var.attach_tgw)&& (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1 : 0}"
+  count = "${(var.attach_tgw  && var.attach_tgw_route_vpc ? false:true) && (var.create_tgw || var.attach_tgw )&& (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1 : 0}"
 
   transit_gateway_attachment_id  = "${element(aws_ec2_transit_gateway_vpc_attachment.this.*.id, 0)}"
   transit_gateway_route_table_id = "${element(aws_ec2_transit_gateway_route_table.this.*.id, 0)}"
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
-  count = "${(var.create_tgw || var.attach_tgw) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1 : 0}"
+  count = "${(var.attach_tgw  && var.attach_tgw_route_vpc ? false:true) && (var.create_tgw || var.attach_tgw) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1 : 0}"
 
   transit_gateway_attachment_id  = "${element(aws_ec2_transit_gateway_vpc_attachment.this.*.id, 0)}"
   transit_gateway_route_table_id = "${element(aws_ec2_transit_gateway_route_table.this.*.id, 0)}"
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "existing_rt" {
+  count = "${((var.attach_tgw  && var.attach_tgw_route_vpc) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1:0)}" 
+
+  transit_gateway_attachment_id  = "${element(aws_ec2_transit_gateway_vpc_attachment.this.*.id, 0)}"
+  transit_gateway_route_table_id =  "${var.tgw_rt_id}"
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "existing_rt" {
+  count = "${((var.attach_tgw  && var.attach_tgw_route_vpc) && (var.subnet_type_tgw_attachment == "private" || var.subnet_type_tgw_attachment == "public") ? 1:0)}" 
+  
+  transit_gateway_attachment_id  = "${element(aws_ec2_transit_gateway_vpc_attachment.this.*.id, 0)}"
+  transit_gateway_route_table_id =  "${var.tgw_rt_id}"
 }
 
 ########

--- a/outputs.tf
+++ b/outputs.tf
@@ -381,3 +381,9 @@ output "tgw_id" {
   description = "Transit Gateway ID"
   value       = "${aws_ec2_transit_gateway.this.*.id}"
 }
+
+
+output "tgw_rt_id" {
+  description = "Transit Gateway Route table ID"
+  value = "${element(concat(aws_ec2_transit_gateway_route_table.this.*.id, list(var.tgw_rt_id)), 0)}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,16 @@ variable "attach_tgw" {
   default = false
 }
 
+variable "attach_tgw_route_vpc" {
+  description = "Works only when attach_tgw is true.This will attach an existing TGW to the VPC ,creates propagation and assocication in existing tgw RT ."
+  default = false
+}
+
+variable "tgw_rt_id" {
+  description = "Works only when attach_tgw and attach_tgw_route_vpc is true.Provide the existing TGW Route table id which already has association and propagation for other VPC attachments"
+  default = ""
+}
+
 variable "attach_tgw_id" {
   description = "TGW ID to attach to the VPC this variable works in conjunction with attach_tgw"
   default = ""
@@ -24,14 +34,13 @@ variable "share_tgw" {
 }
 
 variable "subnet_type_tgw_attachment" {
-  description = "This parameter is considered only if create_tgw is true.Provide the subnet type needed to be added for TGW Attachment . Value can be either private or public"
+  description = "This parameter is considered only if create_tgw is true.Provide the subnet type needed to be added for TGW Attachment . Value can be either private or public."
   default     = "private"
 }
 
 variable "cidr_tgw" {
-  description = "This parameter is considered only if create_tgw is true.Provide valid cidr blocks which will be Destination of TGW .This configuration will be added in Route tables"
+  description = "This parameter is considered only if create_tgw is true.Provide valid cidr blocks which will be Destination of TGW . If attach_tgw_route_vpc is true , you can provide that exisiting VPC's CIDR values.This configuration will be added in Route tables."
   default     = []
-
   type = "list"
 }
 


### PR DESCRIPTION
Steps performed :
1. Creates VPC
2. Uses existing TGW and TGW Route table id.
3. Created VPC Attachment and adds it in the existing TGW Route table which might have attachments of other VPCs which we intend to connect .
4. Update the subnet route table with the CIDR Values of VPCs which the new VPC wants to communicate.